### PR TITLE
add patch method

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -193,7 +193,7 @@ enum State {
   DONE = 4,
 }
 
-const METHODS = ["GET", "HEAD", "POST", "DELETE", "OPTIONS", "PUT"];
+const METHODS = ["GET", "HEAD", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"];
 
 export class XMLHttpRequest extends XMLHttpRequestEventTarget {
   #abortedFlag = false;


### PR DESCRIPTION
I dont why `patch` is not included, but this works well with `@directus/sdk`, I think we should add this.